### PR TITLE
Fix #12

### DIFF
--- a/DiffPriv/__init__.py
+++ b/DiffPriv/__init__.py
@@ -42,5 +42,3 @@ def _sanity_check():
 _sanity_check()
 
 del _sanity_check
-
-import numpy as np # Import Numpy after sanity check passes

--- a/DiffPriv/__init__.py
+++ b/DiffPriv/__init__.py
@@ -1,21 +1,7 @@
-# Import Requirements
-try:
-    import numpy as np
-except ImportError: # pragma: no cover
-    raise ImportError(' \
-        Please make sure you have numpy installed. If you have cloned the package from the source, then use: \
-            pip install -r requirements.txt \
-    ')
-try:
-    import luddite
-except ImportError: # pragma: no cover
-    raise ImportError(' \
-        Please make sure you have luddite installed. If you have cloned the package from the source, then use: \
-            pip install -r requirements.txt \
-    ')
-
 import warnings
 import sys
+import json
+from urllib import request
 
 # Local
 from . import diff
@@ -29,9 +15,21 @@ __source__ = 'https://github.com/Quantalabs/DiffPriv'
 __docs__ = 'https://diffpriv.readthedocs.io'
 
 def _sanity_check():
-    # Check for any new versions of the package
+    # Import Requirements
     try:
-        assert __version__ == luddite.get_version_pypi("DiffPriv")
+        import numpy as np
+    except ImportError: # pragma: no cover
+        raise ImportError(' \
+            Please make sure you have numpy installed. If you have cloned the package from the source, then use: \
+                pip install -r requirements.txt \
+        ')
+    
+    url = f'https://pypi.python.org/pypi/DiffPriv/json'
+    releases = json.loads(request.urlopen(url).read())['releases']
+    latest_version = list(releases.items())[-1]
+
+    try:
+        assert __version__ == latest_version[0]
     except AssertionError:  # pragma: no cover
         # We ignore code coverage for this because there is no way to test this through pytest, but it has been tested manually
         warnings.warn(
@@ -44,3 +42,5 @@ def _sanity_check():
 _sanity_check()
 
 del _sanity_check
+
+import numpy as np # Import Numpy after sanity check passes

--- a/DiffPriv/__init__.py
+++ b/DiffPriv/__init__.py
@@ -29,7 +29,7 @@ def _sanity_check():
     latest_version = list(releases.items())[-1]
 
     try:
-        assert __version__ == latest_version[0]
+        assert __version__ == latest_version[0] # skipcq: BAN-B101
     except AssertionError:  # pragma: no cover
         # We ignore code coverage for this because there is no way to test this through pytest, but it has been tested manually
         warnings.warn(

--- a/DiffPriv/cli.py
+++ b/DiffPriv/cli.py
@@ -113,7 +113,7 @@ def help(command=None):
         print('\n\33[31mportadec\33[0m')
         print('Decrypts file with the porta cipher. Format is \33[1mdiffpriv portadec input_file output_file key\33[0m Last option is passed in as text not a file. Ex. \33[1mdiffpriv portadec file.txt output.txt thisisthekey\33[0m')
     else:
-        eval('print('+command+'.__doc__)')
+        eval('print('+command+'.__doc__)') # skipcq: PYL-W0123
 
 def run(args=sys.argv):
     if args[1] == 'lfl':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 numpy
-luddite


### PR DESCRIPTION
# Pull Request Template
___

## New Feature
Remove the `luddite` requirement as requested in issue #12 and instead fetches the data straight from PyPI with it's JSON API.

## Known Issues
#12 - Fixes issue through using the PyPI JSON API

## Code Breakdown
`DiffPriv/__init__.py`:
 - Remove `luddite` req
 - Use PyPI JSON API to fetch package data
 - Move numpy import check to the sanity check

**Update with commit 9095f28**:

`requirements.txt`: 
 - Remove `luddite` from package list

## Additional Notes
Closes #12 